### PR TITLE
handle NULL pointer

### DIFF
--- a/002_get_fs_type/get_fs_type.c
+++ b/002_get_fs_type/get_fs_type.c
@@ -9,6 +9,9 @@ static int __init get_fs_type_init(void)
 	const	char *name = "ext4";
 
 	struct file_system_type *fst = get_fs_type(name);
+	if (fst == NULL){
+		printk(KERN_ALERT "NULL pointer error");
+	}
 
 	printk(KERN_ALERT "The filesystem's name is : %s\n", fst->name);
 	return 0;


### PR DESCRIPTION
instead you should always check if it has returned a proper pointer or not, else a NULL if not successful.

```
struct file_system_type *fst = get_fs_type(name);
if(fst==NULL) { /* then handle error or go out of function or return, etc ... */ }
printk(KERN_ALERT "The filesystem's name is : %s\n", fst->name);
```